### PR TITLE
Day 1-2: Kinesis data pipeline — poller, normalizer, DynamoDB, S3/Firehose

### DIFF
--- a/cdk/lib/data-stack.ts
+++ b/cdk/lib/data-stack.ts
@@ -1,9 +1,157 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import * as kinesis from 'aws-cdk-lib/aws-kinesis';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as lambdaEventSources from 'aws-cdk-lib/aws-lambda-event-sources';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as firehose from 'aws-cdk-lib/aws-kinesisfirehose';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as path from 'path';
 
 export class DataStack extends cdk.Stack {
+  public readonly stream: kinesis.Stream;
+  public readonly aircraftTable: dynamodb.Table;
+  public readonly archiveBucket: s3.Bucket;
+
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
-    // Day 1-2: Kinesis, DynamoDB, S3, Firehose
+
+    // Kinesis Data Stream — 1 shard, 24h retention, partition by icao24
+    this.stream = new kinesis.Stream(this, 'FlightStream', {
+      streamName: 'flight-positions',
+      shardCount: 1,
+      retentionPeriod: cdk.Duration.hours(24),
+    });
+
+    // DynamoDB Aircraft table — on-demand, TTL for auto-expiry after 24h
+    this.aircraftTable = new dynamodb.Table(this, 'AircraftTable', {
+      tableName: 'Aircraft',
+      partitionKey: { name: 'icao24', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: 'ttl',
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    // S3 archive bucket for Firehose
+    this.archiveBucket = new s3.Bucket(this, 'PositionsArchive', {
+      bucketName: `up-in-the-sky-positions-${this.account}-${this.region}`,
+      lifecycleRules: [{ expiration: cdk.Duration.days(90) }],
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+
+    // IAM role for Firehose to read Kinesis and write S3
+    const firehoseRole = new iam.Role(this, 'FirehoseRole', {
+      assumedBy: new iam.ServicePrincipal('firehose.amazonaws.com'),
+    });
+    this.stream.grantRead(firehoseRole);
+    this.archiveBucket.grantWrite(firehoseRole);
+
+    const firehoseLogGroup = new logs.LogGroup(this, 'FirehoseLogGroup', {
+      logGroupName: '/aws/kinesisfirehose/flight-positions',
+      retention: logs.RetentionDays.ONE_WEEK,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+    new logs.LogStream(this, 'FirehoseLogStream', {
+      logGroup: firehoseLogGroup,
+      logStreamName: 'S3Delivery',
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+    firehoseRole.addToPolicy(new iam.PolicyStatement({
+      actions: ['logs:PutLogEvents'],
+      resources: [firehoseLogGroup.logGroupArn],
+    }));
+
+    // Firehose: Kinesis → S3, partitioned by time, 5-min or 128MB buffers
+    new firehose.CfnDeliveryStream(this, 'FlightFirehose', {
+      deliveryStreamName: 'flight-positions-archive',
+      deliveryStreamType: 'KinesisStreamAsSource',
+      kinesisStreamSourceConfiguration: {
+        kinesisStreamArn: this.stream.streamArn,
+        roleArn: firehoseRole.roleArn,
+      },
+      s3DestinationConfiguration: {
+        bucketArn: this.archiveBucket.bucketArn,
+        roleArn: firehoseRole.roleArn,
+        prefix: 'positions/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/hour=!{timestamp:HH}/',
+        errorOutputPrefix: 'errors/!{firehose:error-output-type}/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/',
+        bufferingHints: {
+          intervalInSeconds: 300,
+          sizeInMBs: 128,
+        },
+        compressionFormat: 'GZIP',
+        cloudWatchLoggingOptions: {
+          enabled: true,
+          logGroupName: firehoseLogGroup.logGroupName,
+          logStreamName: 'S3Delivery',
+        },
+      },
+    });
+
+    // Poller Lambda — runs for 55s per invocation, polls adsb.lol every 2s
+    const pollerLambda = new lambda.Function(this, 'PollerLambda', {
+      functionName: 'flight-poller',
+      runtime: lambda.Runtime.JAVA_21,
+      handler: 'com.upinthesky.poller.PollerHandler::handleRequest',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../../services/poller-lambda'), {
+        bundling: {
+          image: lambda.Runtime.JAVA_21.bundlingImage,
+          command: [
+            '/bin/sh', '-c',
+            'mvn clean package -q -DskipTests && cp target/poller-lambda.jar /asset-output/',
+          ],
+        },
+      }),
+      timeout: cdk.Duration.seconds(60),
+      memorySize: 512,
+      reservedConcurrentExecutions: 1,
+      environment: {
+        KINESIS_STREAM_NAME: this.stream.streamName,
+        POLL_CENTER_LAT: '39.0',
+        POLL_CENTER_LON: '-98.0',
+        POLL_RADIUS_NM: '2000',
+      },
+    });
+    this.stream.grantWrite(pollerLambda);
+
+    // EventBridge triggers poller every minute; Lambda loops internally every 2s
+    new events.Rule(this, 'PollerSchedule', {
+      ruleName: 'flight-poller-schedule',
+      schedule: events.Schedule.rate(cdk.Duration.minutes(1)),
+      targets: [new targets.LambdaFunction(pollerLambda)],
+    });
+
+    // Normalizer Lambda — consumes Kinesis, normalizes, writes DynamoDB
+    const normalizerLambda = new lambda.Function(this, 'NormalizerLambda', {
+      functionName: 'flight-normalizer',
+      runtime: lambda.Runtime.JAVA_21,
+      handler: 'com.upinthesky.normalizer.NormalizerHandler::handleRequest',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../../services/normalizer-lambda'), {
+        bundling: {
+          image: lambda.Runtime.JAVA_21.bundlingImage,
+          command: [
+            '/bin/sh', '-c',
+            'mvn clean package -q -DskipTests && cp target/normalizer-lambda.jar /asset-output/',
+          ],
+        },
+      }),
+      timeout: cdk.Duration.seconds(60),
+      memorySize: 512,
+      environment: {
+        AIRCRAFT_TABLE_NAME: this.aircraftTable.tableName,
+      },
+    });
+    this.aircraftTable.grantReadWriteData(normalizerLambda);
+
+    // Kinesis event source: batch size 100, bisect on error for resilience
+    normalizerLambda.addEventSource(new lambdaEventSources.KinesisEventSource(this.stream, {
+      startingPosition: lambda.StartingPosition.LATEST,
+      batchSize: 100,
+      bisectBatchOnError: true,
+    }));
   }
 }

--- a/cdk/lib/data-stack.ts
+++ b/cdk/lib/data-stack.ts
@@ -102,7 +102,7 @@ export class DataStack extends cdk.Stack {
           image: lambda.Runtime.JAVA_21.bundlingImage,
           command: [
             '/bin/sh', '-c',
-            'mvn clean package -q -DskipTests && cp target/poller-lambda.jar /asset-output/',
+            'mvn clean package -q -DskipTests -Dmaven.repo.local=/tmp/m2 && cp target/poller-lambda.jar /asset-output/',
           ],
         },
       }),
@@ -135,7 +135,7 @@ export class DataStack extends cdk.Stack {
           image: lambda.Runtime.JAVA_21.bundlingImage,
           command: [
             '/bin/sh', '-c',
-            'mvn clean package -q -DskipTests && cp target/normalizer-lambda.jar /asset-output/',
+            'mvn clean package -q -DskipTests -Dmaven.repo.local=/tmp/m2 && cp target/normalizer-lambda.jar /asset-output/',
           ],
         },
       }),

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -24,7 +24,7 @@
     "typeRoots": [
       "./node_modules/@types"
     ],
-    "types": ["node"]
+    "types": ["node", "jest"]
   },
   "exclude": [
     "node_modules",

--- a/services/normalizer-lambda/pom.xml
+++ b/services/normalizer-lambda/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.upinthesky</groupId>
+  <artifactId>normalizer-lambda</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <aws.sdk.version>2.25.0</aws.sdk.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${aws.sdk.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-lambda-java-core</artifactId>
+      <version>1.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-lambda-java-events</artifactId>
+      <version>3.14.0</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>dynamodb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>url-connection-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.17.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>normalizer-lambda</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/services/normalizer-lambda/src/main/java/com/upinthesky/normalizer/NormalizerHandler.java
+++ b/services/normalizer-lambda/src/main/java/com/upinthesky/normalizer/NormalizerHandler.java
@@ -1,0 +1,141 @@
+package com.upinthesky.normalizer;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.upinthesky.normalizer.model.Aircraft;
+import com.upinthesky.normalizer.model.RouteInfo;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+public class NormalizerHandler implements RequestHandler<KinesisEvent, String> {
+
+    private static final DynamoDbClient dynamoDb = DynamoDbClient.builder()
+            .region(Region.of(System.getenv().getOrDefault("AWS_REGION", "us-east-1")))
+            .build();
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final String TABLE_NAME = System.getenv("AIRCRAFT_TABLE_NAME");
+    private static final long TTL_SECONDS = 24 * 3600L;
+    private static final long ROUTE_REFRESH_SECONDS = 3600L;
+
+    private final RouteEnricher routeEnricher = new RouteEnricher();
+
+    @Override
+    public String handleRequest(KinesisEvent event, Context context) {
+        int processed = 0;
+        int errors = 0;
+
+        for (KinesisEvent.KinesisEventRecord record : event.getRecords()) {
+            try {
+                byte[] data = record.getKinesis().getData().array();
+                String json = new String(data, StandardCharsets.UTF_8);
+                Aircraft aircraft = mapper.readValue(json, Aircraft.class);
+
+                if (aircraft.getHex() == null || aircraft.getHex().isBlank()) continue;
+                if (aircraft.getLat() == null || aircraft.getLon() == null) continue;
+
+                upsertAircraft(aircraft, context);
+                processed++;
+            } catch (Exception e) {
+                errors++;
+                context.getLogger().log("Normalize error: " + e.getMessage() + "\n");
+            }
+        }
+        return String.format("processed=%d errors=%d", processed, errors);
+    }
+
+    private void upsertAircraft(Aircraft a, Context context) {
+        String icao24 = a.getHex().toLowerCase();
+        String callsign = a.getFlight();
+        long now = Instant.now().getEpochSecond();
+
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("icao24", str(icao24));
+        item.put("updatedAt", str(Instant.now().toString()));
+        item.put("ttl", num(String.valueOf(now + TTL_SECONDS)));
+
+        if (callsign != null && !callsign.isBlank()) {
+            item.put("callsign", str(callsign));
+        }
+        if (a.getLat() != null) item.put("lat", num(String.valueOf(a.getLat())));
+        if (a.getLon() != null) item.put("lon", num(String.valueOf(a.getLon())));
+        if (a.getAltitudeFeet() != null) item.put("altitude", num(String.valueOf(a.getAltitudeFeet())));
+        if (a.getGs() != null) item.put("groundSpeed", num(String.valueOf(a.getGs())));
+        if (a.getTrack() != null) item.put("track", num(String.valueOf(a.getTrack())));
+        item.put("onGround", bool(a.isOnGround()));
+
+        // Route enrichment: fetch on first sight or if routeUpdatedAt is > 1 hour old
+        if (callsign != null && !callsign.isBlank() && shouldRefreshRoute(icao24, now)) {
+            try {
+                RouteInfo route = routeEnricher.fetchRoute(callsign);
+                if (route != null && route.getOrigin() != null) {
+                    item.put("origin", str(route.getOrigin().getIata()));
+                    item.put("destination", str(route.getDestination().getIata()));
+                    item.put("routeUpdatedAt", str(Instant.now().toString()));
+                }
+            } catch (Exception e) {
+                context.getLogger().log("Route enrichment failed for " + callsign + ": " + e.getMessage() + "\n");
+            }
+        } else {
+            // Preserve existing route fields — only update position fields
+            Map<String, AttributeValue> existing = getExistingRoute(icao24);
+            if (existing != null) {
+                if (existing.containsKey("origin")) item.put("origin", existing.get("origin"));
+                if (existing.containsKey("destination")) item.put("destination", existing.get("destination"));
+                if (existing.containsKey("routeUpdatedAt")) item.put("routeUpdatedAt", existing.get("routeUpdatedAt"));
+            }
+        }
+
+        dynamoDb.putItem(PutItemRequest.builder()
+                .tableName(TABLE_NAME)
+                .item(item)
+                .build());
+    }
+
+    private boolean shouldRefreshRoute(String icao24, long nowEpochSeconds) {
+        Map<String, AttributeValue> existing = getExistingRoute(icao24);
+        if (existing == null || !existing.containsKey("routeUpdatedAt")) return true;
+        try {
+            String routeUpdatedAt = existing.get("routeUpdatedAt").s();
+            long routeAge = nowEpochSeconds - Instant.parse(routeUpdatedAt).getEpochSecond();
+            return routeAge > ROUTE_REFRESH_SECONDS;
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    private Map<String, AttributeValue> getExistingRoute(String icao24) {
+        try {
+            GetItemResponse response = dynamoDb.getItem(GetItemRequest.builder()
+                    .tableName(TABLE_NAME)
+                    .key(Map.of("icao24", str(icao24)))
+                    .projectionExpression("origin, destination, routeUpdatedAt")
+                    .build());
+            return response.hasItem() ? response.item() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static AttributeValue str(String s) {
+        return AttributeValue.builder().s(s).build();
+    }
+
+    private static AttributeValue num(String n) {
+        return AttributeValue.builder().n(n).build();
+    }
+
+    private static AttributeValue bool(boolean b) {
+        return AttributeValue.builder().bool(b).build();
+    }
+}

--- a/services/normalizer-lambda/src/main/java/com/upinthesky/normalizer/RouteEnricher.java
+++ b/services/normalizer-lambda/src/main/java/com/upinthesky/normalizer/RouteEnricher.java
@@ -1,0 +1,45 @@
+package com.upinthesky.normalizer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.upinthesky.normalizer.model.RouteInfo;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+public class RouteEnricher {
+
+    private static final String ROUTE_BASE_URL = "https://api.adsb.lol/api/0/route";
+    private static final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * Fetches origin/destination for a callsign from adsb.lol.
+     * Returns null if the callsign is blank, the lookup fails, or the API returns no route.
+     */
+    public RouteInfo fetchRoute(String callsign) {
+        if (callsign == null || callsign.isBlank()) return null;
+        try {
+            String url = ROUTE_BASE_URL + "/" + callsign.strip();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(5))
+                    .header("Accept", "application/json")
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 404) return null;
+            if (response.statusCode() != 200) {
+                throw new RuntimeException("Route API returned HTTP " + response.statusCode());
+            }
+            return mapper.readValue(response.body(), RouteInfo.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/services/normalizer-lambda/src/main/java/com/upinthesky/normalizer/model/Aircraft.java
+++ b/services/normalizer-lambda/src/main/java/com/upinthesky/normalizer/model/Aircraft.java
@@ -1,0 +1,63 @@
+package com.upinthesky.normalizer.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Aircraft {
+
+    private String hex;
+    private String flight;
+    private Double lat;
+    private Double lon;
+
+    @JsonProperty("alt_baro")
+    private Object altBaro;
+
+    private Double gs;
+    private Double track;
+    private String squawk;
+    private String type;
+    private Long polledAt;
+
+    public String getHex() { return hex; }
+    public void setHex(String hex) { this.hex = hex; }
+
+    public String getFlight() { return flight != null ? flight.trim() : null; }
+    public void setFlight(String flight) { this.flight = flight; }
+
+    public Double getLat() { return lat; }
+    public void setLat(Double lat) { this.lat = lat; }
+
+    public Double getLon() { return lon; }
+    public void setLon(Double lon) { this.lon = lon; }
+
+    public Object getAltBaro() { return altBaro; }
+    public void setAltBaro(Object altBaro) { this.altBaro = altBaro; }
+
+    public Double getGs() { return gs; }
+    public void setGs(Double gs) { this.gs = gs; }
+
+    public Double getTrack() { return track; }
+    public void setTrack(Double track) { this.track = track; }
+
+    public String getSquawk() { return squawk; }
+    public void setSquawk(String squawk) { this.squawk = squawk; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public Long getPolledAt() { return polledAt; }
+    public void setPolledAt(Long polledAt) { this.polledAt = polledAt; }
+
+    public boolean isOnGround() {
+        return "ground".equals(altBaro);
+    }
+
+    public Integer getAltitudeFeet() {
+        if (altBaro instanceof Number) {
+            return ((Number) altBaro).intValue();
+        }
+        return null;
+    }
+}

--- a/services/normalizer-lambda/src/main/java/com/upinthesky/normalizer/model/RouteInfo.java
+++ b/services/normalizer-lambda/src/main/java/com/upinthesky/normalizer/model/RouteInfo.java
@@ -1,0 +1,42 @@
+package com.upinthesky.normalizer.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RouteInfo {
+
+    private String callsign;
+
+    @JsonProperty("_airport_codes_iata")
+    private String airportCodesIata;
+
+    private AirportRef origin;
+    private AirportRef destination;
+
+    public String getCallsign() { return callsign; }
+    public void setCallsign(String callsign) { this.callsign = callsign; }
+
+    public String getAirportCodesIata() { return airportCodesIata; }
+    public void setAirportCodesIata(String airportCodesIata) {
+        this.airportCodesIata = airportCodesIata;
+    }
+
+    public AirportRef getOrigin() { return origin; }
+    public void setOrigin(AirportRef origin) { this.origin = origin; }
+
+    public AirportRef getDestination() { return destination; }
+    public void setDestination(AirportRef destination) { this.destination = destination; }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class AirportRef {
+        private String iata;
+        private String name;
+
+        public String getIata() { return iata; }
+        public void setIata(String iata) { this.iata = iata; }
+
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+    }
+}

--- a/services/poller-lambda/pom.xml
+++ b/services/poller-lambda/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.upinthesky</groupId>
+  <artifactId>poller-lambda</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <aws.sdk.version>2.25.0</aws.sdk.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${aws.sdk.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-lambda-java-core</artifactId>
+      <version>1.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>kinesis</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>url-connection-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.17.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>poller-lambda</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/services/poller-lambda/src/main/java/com/upinthesky/poller/AdsbApiClient.java
+++ b/services/poller-lambda/src/main/java/com/upinthesky/poller/AdsbApiClient.java
@@ -1,0 +1,40 @@
+package com.upinthesky.poller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.upinthesky.poller.model.AdsbResponse;
+import com.upinthesky.poller.model.Aircraft;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+public class AdsbApiClient {
+
+    private static final String BASE_URL = "https://api.adsb.lol/v2";
+    private static final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public List<Aircraft> fetchPositions(double lat, double lon, int radiusNm) throws Exception {
+        String url = String.format("%s/lat/%.4f/lon/%.4f/dist/%d", BASE_URL, lat, lon, radiusNm);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(8))
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            throw new RuntimeException("adsb.lol positions API returned HTTP " + response.statusCode());
+        }
+
+        AdsbResponse adsbResponse = mapper.readValue(response.body(), AdsbResponse.class);
+        return adsbResponse.getAc() != null ? adsbResponse.getAc() : Collections.emptyList();
+    }
+}

--- a/services/poller-lambda/src/main/java/com/upinthesky/poller/PollerHandler.java
+++ b/services/poller-lambda/src/main/java/com/upinthesky/poller/PollerHandler.java
@@ -1,0 +1,97 @@
+package com.upinthesky.poller;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.upinthesky.poller.model.Aircraft;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsResponse;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class PollerHandler implements RequestHandler<Map<String, Object>, String> {
+
+    private static final KinesisClient kinesisClient = KinesisClient.builder()
+            .region(Region.of(System.getenv().getOrDefault("AWS_REGION", "us-east-1")))
+            .build();
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static final String STREAM_NAME = System.getenv("KINESIS_STREAM_NAME");
+    private static final double LAT = Double.parseDouble(
+            System.getenv().getOrDefault("POLL_CENTER_LAT", "39.0"));
+    private static final double LON = Double.parseDouble(
+            System.getenv().getOrDefault("POLL_CENTER_LON", "-98.0"));
+    private static final int RADIUS_NM = Integer.parseInt(
+            System.getenv().getOrDefault("POLL_RADIUS_NM", "2000"));
+
+    // EventBridge minimum schedule is 1 minute; loop internally for 2-second cadence
+    private static final long LOOP_DURATION_MS = 55_000L;
+    private static final int POLL_INTERVAL_MS = 2_000;
+    private static final int KINESIS_BATCH_LIMIT = 500;
+
+    private final AdsbApiClient apiClient = new AdsbApiClient();
+
+    @Override
+    public String handleRequest(Map<String, Object> input, Context context) {
+        long startMs = System.currentTimeMillis();
+        int iterations = 0;
+        int errors = 0;
+
+        while (System.currentTimeMillis() - startMs < LOOP_DURATION_MS) {
+            try {
+                long pollTimestamp = Instant.now().toEpochMilli();
+                List<Aircraft> aircraft = apiClient.fetchPositions(LAT, LON, RADIUS_NM);
+
+                if (!aircraft.isEmpty()) {
+                    for (Aircraft a : aircraft) {
+                        a.setPolledAt(pollTimestamp);
+                    }
+                    int pushed = pushToKinesis(aircraft);
+                    context.getLogger().log(String.format(
+                            "iter=%d aircraft=%d pushed=%d%n",
+                            iterations + 1, aircraft.size(), pushed));
+                }
+                iterations++;
+                Thread.sleep(POLL_INTERVAL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                errors++;
+                context.getLogger().log("Poll error: " + e.getMessage() + "\n");
+            }
+        }
+        return String.format("iterations=%d errors=%d", iterations, errors);
+    }
+
+    private int pushToKinesis(List<Aircraft> aircraft) throws Exception {
+        List<PutRecordsRequestEntry> entries = new ArrayList<>(aircraft.size());
+        for (Aircraft a : aircraft) {
+            if (a.getHex() == null || a.getHex().isBlank()) continue;
+            String json = mapper.writeValueAsString(a);
+            entries.add(PutRecordsRequestEntry.builder()
+                    .data(SdkBytes.fromUtf8String(json))
+                    .partitionKey(a.getHex())
+                    .build());
+        }
+
+        int pushed = 0;
+        for (int i = 0; i < entries.size(); i += KINESIS_BATCH_LIMIT) {
+            List<PutRecordsRequestEntry> batch = entries.subList(
+                    i, Math.min(i + KINESIS_BATCH_LIMIT, entries.size()));
+            PutRecordsResponse response = kinesisClient.putRecords(PutRecordsRequest.builder()
+                    .streamName(STREAM_NAME)
+                    .records(batch)
+                    .build());
+            pushed += batch.size() - response.failedRecordCount();
+        }
+        return pushed;
+    }
+}

--- a/services/poller-lambda/src/main/java/com/upinthesky/poller/model/AdsbResponse.java
+++ b/services/poller-lambda/src/main/java/com/upinthesky/poller/model/AdsbResponse.java
@@ -1,0 +1,21 @@
+package com.upinthesky.poller.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AdsbResponse {
+
+    private List<Aircraft> ac;
+    private Integer total;
+    private Double now;
+
+    public List<Aircraft> getAc() { return ac; }
+    public void setAc(List<Aircraft> ac) { this.ac = ac; }
+
+    public Integer getTotal() { return total; }
+    public void setTotal(Integer total) { this.total = total; }
+
+    public Double getNow() { return now; }
+    public void setNow(Double now) { this.now = now; }
+}

--- a/services/poller-lambda/src/main/java/com/upinthesky/poller/model/Aircraft.java
+++ b/services/poller-lambda/src/main/java/com/upinthesky/poller/model/Aircraft.java
@@ -1,0 +1,72 @@
+package com.upinthesky.poller.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Aircraft {
+
+    private String hex;
+    private String flight;
+    private Double lat;
+    private Double lon;
+
+    // alt_baro can be a number (feet) or the string "ground"
+    @JsonProperty("alt_baro")
+    private Object altBaro;
+
+    private Double gs;
+    private Double track;
+    private String squawk;
+    private String type;
+    private String r;   // registration
+    private String t;   // type designator
+    private Long polledAt;
+
+    public String getHex() { return hex; }
+    public void setHex(String hex) { this.hex = hex; }
+
+    public String getFlight() { return flight != null ? flight.trim() : null; }
+    public void setFlight(String flight) { this.flight = flight; }
+
+    public Double getLat() { return lat; }
+    public void setLat(Double lat) { this.lat = lat; }
+
+    public Double getLon() { return lon; }
+    public void setLon(Double lon) { this.lon = lon; }
+
+    public Object getAltBaro() { return altBaro; }
+    public void setAltBaro(Object altBaro) { this.altBaro = altBaro; }
+
+    public Double getGs() { return gs; }
+    public void setGs(Double gs) { this.gs = gs; }
+
+    public Double getTrack() { return track; }
+    public void setTrack(Double track) { this.track = track; }
+
+    public String getSquawk() { return squawk; }
+    public void setSquawk(String squawk) { this.squawk = squawk; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public String getR() { return r; }
+    public void setR(String r) { this.r = r; }
+
+    public String getT() { return t; }
+    public void setT(String t) { this.t = t; }
+
+    public Long getPolledAt() { return polledAt; }
+    public void setPolledAt(Long polledAt) { this.polledAt = polledAt; }
+
+    public boolean isOnGround() {
+        return "ground".equals(altBaro);
+    }
+
+    public Integer getAltitudeFeet() {
+        if (altBaro instanceof Number) {
+            return ((Number) altBaro).intValue();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

- **CDK `DataStack`** — Kinesis stream (1 shard, 24 h retention), DynamoDB `Aircraft` table (on-demand, TTL), S3 archive bucket, Firehose (Kinesis→S3, time-partitioned, GZIP, 5 min/128 MB buffer)
- **`poller-lambda` (Java 21)** — EventBridge triggers every minute; loops 55 s internally calling adsb.lol `/v2` every 2 s, batch-puts per-aircraft JSON to Kinesis partitioned by `icao24`; `reservedConcurrentExecutions=1` prevents overlap
- **`normalizer-lambda` (Java 21)** — Kinesis event source (batch=100, bisect-on-error); normalises position records into DynamoDB with 24 h TTL; enriches `origin`/`destination` via adsb.lol route API on first sight or after 1 h staleness; stores `null` when unavailable

Both Lambdas are built at deploy time via the `public.ecr.aws/sam/build-java21` bundling image + Maven Shade fat JAR.

## Test plan

- [ ] `cd cdk && npm run build` — TypeScript compiles without errors
- [ ] `cdk synth data-stack` — stack synthesises cleanly
- [ ] `cdk deploy data-stack` — all resources created successfully
- [ ] After ~2 min, DynamoDB `Aircraft` table has live records updating every ~2 s
- [ ] CloudWatch logs for `flight-poller` show `iter=N aircraft=M pushed=M`
- [ ] CloudWatch logs for `flight-normalizer` show `processed=N errors=0`
- [ ] S3 bucket has GZIP objects under `positions/year=.../` after ~5 min
- [ ] Airborne aircraft records have `origin`/`destination` populated after ~1 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)