### PR TITLE
fix: add kinesis:DescribeStream to Firehose role

### DIFF
--- a/cdk/lib/data-stack.ts
+++ b/cdk/lib/data-stack.ts
@@ -49,6 +49,10 @@ export class DataStack extends cdk.Stack {
       assumedBy: new iam.ServicePrincipal('firehose.amazonaws.com'),
     });
     this.stream.grantRead(firehoseRole);
+    firehoseRole.addToPolicy(new iam.PolicyStatement({
+      actions: ['kinesis:DescribeStream'],
+      resources: [this.stream.streamArn],
+    }));
     this.archiveBucket.grantWrite(firehoseRole);
 
     const firehoseLogGroup = new logs.LogGroup(this, 'FirehoseLogGroup', {


### PR DESCRIPTION
## Summary
- `stream.grantRead()` does not include `kinesis:DescribeStream`, which Firehose requires when configured with a Kinesis stream as its source
- Deploy failed with: *Role is not authorized to perform: kinesis:DescribeStream on resource arn:aws:kinesis:...:stream/flight-positions*
- Added an explicit `PolicyStatement` granting `kinesis:DescribeStream` on the stream ARN to the Firehose role

## Test plan
- [ ] CI synth passes
- [ ] Deploy workflow succeeds after merge — `data-stack` `FlightFirehose` resource creates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)