### PR TITLE
fix: remove hardcoded Kinesis and Firehose names to resolve already-exists conflict

### DIFF
--- a/cdk/lib/data-stack.ts
+++ b/cdk/lib/data-stack.ts
@@ -22,7 +22,6 @@ export class DataStack extends cdk.Stack {
 
     // Kinesis Data Stream — 1 shard, 24h retention, partition by icao24
     this.stream = new kinesis.Stream(this, 'FlightStream', {
-      streamName: 'flight-positions',
       shardCount: 1,
       retentionPeriod: cdk.Duration.hours(24),
     });
@@ -72,7 +71,6 @@ export class DataStack extends cdk.Stack {
 
     // Firehose: Kinesis → S3, partitioned by time, 5-min or 128MB buffers
     new firehose.CfnDeliveryStream(this, 'FlightFirehose', {
-      deliveryStreamName: 'flight-positions-archive',
       deliveryStreamType: 'KinesisStreamAsSource',
       kinesisStreamSourceConfiguration: {
         kinesisStreamArn: this.stream.streamArn,


### PR DESCRIPTION
## Summary
- The `flight-positions` Kinesis stream was created during the first failed deploy attempt and retained after rollback — CloudFormation now rejects any changeset that tries to create a resource with that physical name again
- Same risk applies to the `flight-positions-archive` Firehose delivery stream name
- Removed both hardcoded names so CDK generates unique physical names; all consumers reference the stream via env vars and ARNs, not hard-coded strings

## Test plan
- [ ] CI synth passes
- [ ] Deploy workflow succeeds after merge — `data-stack` creates all resources cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)