### PR TITLE
fix: ensure Firehose waits for IAM policy before creation

### DIFF
--- a/cdk/lib/data-stack.ts
+++ b/cdk/lib/data-stack.ts
@@ -70,7 +70,7 @@ export class DataStack extends cdk.Stack {
     }));
 
     // Firehose: Kinesis → S3, partitioned by time, 5-min or 128MB buffers
-    new firehose.CfnDeliveryStream(this, 'FlightFirehose', {
+    const flightFirehose = new firehose.CfnDeliveryStream(this, 'FlightFirehose', {
       deliveryStreamType: 'KinesisStreamAsSource',
       kinesisStreamSourceConfiguration: {
         kinesisStreamArn: this.stream.streamArn,
@@ -93,6 +93,12 @@ export class DataStack extends cdk.Stack {
         },
       },
     });
+    // Firehose validates IAM at creation time — ensure the role's DefaultPolicy
+    // is fully applied before CloudFormation attempts to create the delivery stream.
+    const firehoseDefaultPolicy = firehoseRole.node.tryFindChild('DefaultPolicy') as iam.Policy;
+    if (firehoseDefaultPolicy) {
+      flightFirehose.node.addDependency(firehoseDefaultPolicy);
+    }
 
     // Poller Lambda — runs for 55s per invocation, polls adsb.lol every 2s
     const pollerLambda = new lambda.Function(this, 'PollerLambda', {


### PR DESCRIPTION
## Summary
- Firehose validates IAM permissions at resource creation time
- CloudFormation was creating `FlightFirehose` and `FirehoseRole/DefaultPolicy` in parallel — the Firehose failed with `kinesis:DescribeStream not authorized` because the policy hadn't been applied yet
- Added an explicit `node.addDependency()` so CloudFormation creates the IAM DefaultPolicy before attempting to create the Firehose delivery stream

## Test plan
- [ ] CI synth passes
- [ ] Deploy workflow succeeds — `FlightFirehose` creates successfully after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)