### PR TITLE
fix: normalizer Lambda timeout under high Kinesis load

### DIFF
--- a/cdk/lib/data-stack.ts
+++ b/cdk/lib/data-stack.ts
@@ -137,7 +137,7 @@ export class DataStack extends cdk.Stack {
       runtime: lambda.Runtime.JAVA_21,
       handler: 'com.upinthesky.normalizer.NormalizerHandler::handleRequest',
       code: lambda.Code.fromAsset(path.join(__dirname, '../../services/normalizer-lambda/target/normalizer-lambda.jar')),
-      timeout: cdk.Duration.seconds(60),
+      timeout: cdk.Duration.seconds(300),
       memorySize: 512,
       environment: {
         AIRCRAFT_TABLE_NAME: this.aircraftTable.tableName,
@@ -145,10 +145,11 @@ export class DataStack extends cdk.Stack {
     });
     this.aircraftTable.grantReadWriteData(normalizerLambda);
 
-    // Kinesis event source: batch size 100, bisect on error for resilience
+    // Kinesis event source: smaller batch + 10s window keeps invocations well under timeout
     normalizerLambda.addEventSource(new lambdaEventSources.KinesisEventSource(this.stream, {
       startingPosition: lambda.StartingPosition.LATEST,
-      batchSize: 100,
+      batchSize: 50,
+      maxBatchingWindow: cdk.Duration.seconds(10),
       bisectBatchOnError: true,
     }));
   }


### PR DESCRIPTION
## Summary
- Observed the normalizer Lambda timing out consistently (6 times in 10 minutes) — the poller pushes ~65k records/min and the 60s timeout wasn't enough headroom
- Increased normalizer timeout: **60s → 300s**
- Reduced Kinesis batch size: **100 → 50** with a **10s batching window** — smaller batches mean each invocation finishes faster, and the window amortises the per-invocation overhead

## Root cause
Each normalizer invocation does ≥2 DynamoDB calls per record (read for route staleness check + write), plus occasional HTTP calls to adsb.lol for route enrichment. With batch size 100 and a steady stream of new aircraft, invocations were regularly exceeding 60s.

## Test plan
- [x] `cdk deploy data-stack` applied the Lambda timeout and EventSourceMapping changes cleanly
- [ ] Verify no `Status: timeout` entries in `/aws/lambda/flight-normalizer` logs after next few minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)