### PR TITLE
feat: implement api-stack WebSocket API and broadcaster

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -12,5 +12,5 @@ const env = {
 };
 
 const dataStack = new DataStack(app, 'data-stack', { env });
-const apiStack = new ApiStack(app, 'api-stack', { env });
+const apiStack = new ApiStack(app, 'api-stack', { env, stream: dataStack.stream });
 new ComputeStack(app, 'compute-stack', { env, aircraftTable: dataStack.aircraftTable });

--- a/cdk/lib/api-stack.ts
+++ b/cdk/lib/api-stack.ts
@@ -1,9 +1,130 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import * as kinesis from 'aws-cdk-lib/aws-kinesis';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as lambdaEventSources from 'aws-cdk-lib/aws-lambda-event-sources';
+import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as apigwv2Integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as path from 'path';
+
+interface ApiStackProps extends cdk.StackProps {
+  stream: kinesis.Stream;
+}
 
 export class ApiStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+  public readonly wsApiUrl: string;
+
+  constructor(scope: Construct, id: string, props: ApiStackProps) {
     super(scope, id, props);
-    // Day 2: API Gateway HTTP + WebSocket
+
+    // DynamoDB table to track live WebSocket connection IDs
+    const connectionsTable = new dynamodb.Table(this, 'ConnectionsTable', {
+      tableName: 'WsConnections',
+      partitionKey: { name: 'connectionId', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: 'ttl',
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    // WebSocket API
+    const wsApi = new apigwv2.WebSocketApi(this, 'FlightWsApi', {
+      apiName: 'flight-ws-api',
+    });
+
+    const wsStage = new apigwv2.WebSocketStage(this, 'FlightWsStage', {
+      webSocketApi: wsApi,
+      stageName: 'prod',
+      autoDeploy: true,
+    });
+
+    // $connect — store connection ID
+    const connectFn = new lambda.Function(this, 'WsConnectFn', {
+      functionName: 'ws-connect',
+      runtime: lambda.Runtime.PYTHON_3_12,
+      handler: 'index.handler',
+      code: lambda.Code.fromInline(
+        'import os,boto3,time\n' +
+        'ddb=boto3.resource("dynamodb")\n' +
+        'table=ddb.Table(os.environ["CONNECTIONS_TABLE"])\n' +
+        'def handler(event,context):\n' +
+        '    table.put_item(Item={"connectionId":event["requestContext"]["connectionId"],"ttl":int(time.time())+86400})\n' +
+        '    return{"statusCode":200}\n'
+      ),
+      environment: { CONNECTIONS_TABLE: connectionsTable.tableName },
+    });
+    connectionsTable.grantReadWriteData(connectFn);
+
+    // $disconnect — remove connection ID
+    const disconnectFn = new lambda.Function(this, 'WsDisconnectFn', {
+      functionName: 'ws-disconnect',
+      runtime: lambda.Runtime.PYTHON_3_12,
+      handler: 'index.handler',
+      code: lambda.Code.fromInline(
+        'import os,boto3\n' +
+        'ddb=boto3.resource("dynamodb")\n' +
+        'table=ddb.Table(os.environ["CONNECTIONS_TABLE"])\n' +
+        'def handler(event,context):\n' +
+        '    table.delete_item(Key={"connectionId":event["requestContext"]["connectionId"]})\n' +
+        '    return{"statusCode":200}\n'
+      ),
+      environment: { CONNECTIONS_TABLE: connectionsTable.tableName },
+    });
+    connectionsTable.grantReadWriteData(disconnectFn);
+
+    wsApi.addRoute('$connect', {
+      integration: new apigwv2Integrations.WebSocketLambdaIntegration('ConnectInt', connectFn),
+    });
+    wsApi.addRoute('$disconnect', {
+      integration: new apigwv2Integrations.WebSocketLambdaIntegration('DisconnectInt', disconnectFn),
+    });
+
+    // Management API endpoint used by broadcaster to post messages to connections
+    const wsManagementEndpoint = `https://${wsApi.apiId}.execute-api.${this.region}.amazonaws.com/${wsStage.stageName}`;
+
+    // Broadcaster Lambda — reads from Kinesis and fans out aircraft_update events to all WebSocket clients
+    const broadcasterFn = new lambda.Function(this, 'BroadcasterFn', {
+      functionName: 'ws-broadcaster',
+      runtime: lambda.Runtime.PYTHON_3_12,
+      handler: 'main.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../../services/broadcaster-lambda')),
+      timeout: cdk.Duration.seconds(60),
+      memorySize: 256,
+      environment: {
+        CONNECTIONS_TABLE: connectionsTable.tableName,
+        WS_MANAGEMENT_ENDPOINT: wsManagementEndpoint,
+      },
+    });
+    connectionsTable.grantReadWriteData(broadcasterFn);
+    props.stream.grantRead(broadcasterFn);
+
+    // Allow broadcaster to post to WebSocket connections
+    broadcasterFn.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['execute-api:ManageConnections'],
+      resources: [
+        `arn:aws:execute-api:${this.region}:${this.account}:${wsApi.apiId}/${wsStage.stageName}/POST/@connections/*`,
+      ],
+    }));
+
+    // Parallel Kinesis consumer alongside the normalizer — 2s batching window for low latency
+    broadcasterFn.addEventSource(new lambdaEventSources.KinesisEventSource(props.stream, {
+      startingPosition: lambda.StartingPosition.LATEST,
+      batchSize: 50,
+      maxBatchingWindow: cdk.Duration.seconds(2),
+      bisectBatchOnError: true,
+    }));
+
+    this.wsApiUrl = wsStage.url;
+
+    new cdk.CfnOutput(this, 'WsApiUrl', {
+      value: wsStage.url,
+      description: 'WebSocket connect URL — wss://... (use as NEXT_PUBLIC_API_WS_URL)',
+    });
+
+    new cdk.CfnOutput(this, 'HttpApiUrl', {
+      value: `https://oyfi3ca3liovtt3ch2hjyeqsjm0jqexa.lambda-url.us-east-1.on.aws`,
+      description: 'Chat service HTTP URL — use as NEXT_PUBLIC_API_HTTP_URL',
+    });
   }
 }

--- a/services/broadcaster-lambda/main.py
+++ b/services/broadcaster-lambda/main.py
@@ -1,0 +1,119 @@
+import base64
+import json
+import os
+import time
+
+import boto3
+from botocore.exceptions import ClientError
+
+CONNECTIONS_TABLE = os.environ["CONNECTIONS_TABLE"]
+WS_MANAGEMENT_ENDPOINT = os.environ["WS_MANAGEMENT_ENDPOINT"]
+
+_ddb = None
+_apigw = None
+
+
+def get_ddb():
+    global _ddb
+    if _ddb is None:
+        _ddb = boto3.resource("dynamodb")
+    return _ddb
+
+
+def get_apigw():
+    global _apigw
+    if _apigw is None:
+        _apigw = boto3.client(
+            "apigatewaymanagementapi", endpoint_url=WS_MANAGEMENT_ENDPOINT
+        )
+    return _apigw
+
+
+def build_ws_message(ac: dict) -> bytes | None:
+    hex_id = (ac.get("hex") or "").strip().lower()
+    if not hex_id or ac.get("lat") is None or ac.get("lon") is None:
+        return None
+
+    alt_baro = ac.get("alt_baro")
+    on_ground = alt_baro == "ground"
+    altitude = 0 if on_ground else (int(alt_baro) if isinstance(alt_baro, (int, float)) else 0)
+
+    polled_at = ac.get("polledAt")
+    updated_at = (
+        time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(polled_at / 1000))
+        if polled_at
+        else time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    )
+
+    msg = {
+        "type": "aircraft_update",
+        "data": {
+            "icao24": hex_id,
+            "callsign": (ac.get("flight") or "").strip(),
+            "lat": ac.get("lat", 0),
+            "lon": ac.get("lon", 0),
+            "altitude": altitude,
+            "groundSpeed": int(ac.get("gs") or 0),
+            "track": int(ac.get("track") or 0),
+            "onGround": on_ground,
+            "updatedAt": updated_at,
+        },
+    }
+    return json.dumps(msg).encode("utf-8")
+
+
+def handler(event, context):
+    # Decode all Kinesis records into aircraft objects
+    aircraft_list: list[dict] = []
+    for record in event.get("Records", []):
+        try:
+            raw = base64.b64decode(record["kinesis"]["data"]).decode("utf-8")
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                aircraft_list.extend(parsed)
+            elif isinstance(parsed, dict):
+                aircraft_list.append(parsed)
+        except Exception as e:
+            print(f"decode error: {e}")
+
+    if not aircraft_list:
+        return
+
+    # Fetch all active connection IDs
+    table = get_ddb().Table(CONNECTIONS_TABLE)
+    scan_resp = table.scan(ProjectionExpression="connectionId")
+    conn_ids: list[str] = [item["connectionId"] for item in scan_resp.get("Items", [])]
+
+    if not conn_ids:
+        return
+
+    # Build messages and broadcast
+    apigw = get_apigw()
+    stale: set[str] = set()
+
+    for ac in aircraft_list:
+        msg = build_ws_message(ac)
+        if not msg:
+            continue
+        for conn_id in conn_ids:
+            if conn_id in stale:
+                continue
+            try:
+                apigw.post_to_connection(ConnectionId=conn_id, Data=msg)
+            except ClientError as e:
+                code = e.response["Error"]["Code"]
+                if code in ("GoneException", "410"):
+                    stale.add(conn_id)
+                else:
+                    print(f"post error {conn_id}: {e}")
+            except Exception as e:
+                print(f"post error {conn_id}: {e}")
+
+    # Remove stale connections
+    for conn_id in stale:
+        try:
+            table.delete_item(Key={"connectionId": conn_id})
+        except Exception as e:
+            print(f"cleanup error {conn_id}: {e}")
+
+    print(f"broadcast: aircraft={len(aircraft_list)} connections={len(conn_ids)} stale={len(stale)}")


### PR DESCRIPTION
## Summary
- Implements the previously-stubbed `api-stack` with a full API Gateway WebSocket API
- `WsConnections` DynamoDB table tracks live browser connection IDs (TTL = 24h)
- `ws-connect` / `ws-disconnect` inline Lambda handlers maintain the connections table
- `ws-broadcaster` Lambda is a parallel Kinesis consumer alongside the Normalizer — it decodes each aircraft batch and fans out `aircraft_update` events to all connected WebSocket clients, auto-removing stale (410 Gone) connections
- CDK entrypoint updated to pass `dataStack.stream` to ApiStack
- Stack outputs `WsApiUrl` and `HttpApiUrl` for the two `NEXT_PUBLIC_*` frontend env vars

## Test plan
- [ ] CI: `cdk synth` compiles cleanly and `cdk diff` shows new resources
- [ ] Deploy: `cdk deploy api-stack` creates WS API, connections table, and broadcaster Lambda
- [ ] Connect a WebSocket client to the `WsApiUrl` output — verify it stays open
- [ ] Confirm broadcaster Lambda logs show `aircraft=N connections=1` after Kinesis events arrive
- [ ] Frontend flight board connects and receives live `aircraft_update` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)