### PR TITLE
fix: batch broadcaster + map view

### DIFF
--- a/frontend/app/components/FlightMap/FlightMap.tsx
+++ b/frontend/app/components/FlightMap/FlightMap.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useWebSocket } from "@/app/hooks/useWebSocket";
+
+const FlightMapInner = dynamic(() => import("./FlightMapInner"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex items-center justify-center w-full h-full bg-gray-950 text-gray-600 text-sm">
+      Loading map…
+    </div>
+  ),
+});
+
+const WS_URL = process.env.NEXT_PUBLIC_API_WS_URL;
+
+export function FlightMap() {
+  const { aircraft, status } = useWebSocket(WS_URL);
+  return <FlightMapInner aircraft={aircraft} status={status} />;
+}

--- a/frontend/app/components/FlightMap/FlightMapInner.tsx
+++ b/frontend/app/components/FlightMap/FlightMapInner.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { MapContainer, TileLayer, useMapEvents } from "react-leaflet";
+import * as L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import type { AircraftData } from "@/app/hooks/useWebSocket";
+
+// ── plane SVG icon, pointed in direction of travel ────────────────────────────
+function planeIcon(track: number, onGround: boolean): L.DivIcon {
+  const color = onGround ? "#6b7280" : "#60a5fa";
+  // SVG drawn nose-up (0°), CSS rotate aligns it to track heading
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20"
+    style="transform:rotate(${track}deg);filter:drop-shadow(0 1px 3px rgba(0,0,0,.7))">
+    <path fill="${color}" d="M12 2L8.5 10H3l2 2 4-.5V17l-3 1.5V20l6-1.5 6 1.5v-1.5L18 17v-5.5l4 .5 2-2h-5.5L12 2z"/>
+  </svg>`;
+  return L.divIcon({ html: svg, className: "", iconSize: [20, 20], iconAnchor: [10, 10] });
+}
+
+// ── imperative marker layer — no React component per aircraft ─────────────────
+function MarkersLayer({ aircraft, bounds }: { aircraft: Map<string, AircraftData>; bounds: L.LatLngBounds | null }) {
+  const map = useMapEvents({});
+  const markers = useRef<Map<string, L.Marker>>(new Map());
+
+  useEffect(() => {
+    const visible = new Set<string>();
+    aircraft.forEach((ac) => {
+      if (bounds && !bounds.contains([ac.lat, ac.lon])) return;
+      visible.add(ac.icao24);
+
+      const latlng: L.LatLngTuple = [ac.lat, ac.lon];
+      const icon = planeIcon(ac.track, ac.onGround);
+      const popupHtml = `
+        <div style="font:12px/1.7 monospace;min-width:140px">
+          <b style="font-size:13px">${ac.callsign || ac.icao24}</b><br>
+          ${ac.onGround ? "<em>On ground</em>" : `${ac.altitude.toLocaleString()} ft`}<br>
+          ${ac.groundSpeed} kts &nbsp;·&nbsp; ${ac.track}°<br>
+          <span style="color:#9ca3af;font-size:11px">${ac.icao24}</span>
+        </div>`;
+
+      const existing = markers.current.get(ac.icao24);
+      if (existing) {
+        existing.setLatLng(latlng).setIcon(icon);
+        existing.getPopup()?.setContent(popupHtml);
+      } else {
+        const m = L.marker(latlng, { icon })
+          .bindPopup(popupHtml, { closeButton: false, maxWidth: 220 })
+          .addTo(map);
+        markers.current.set(ac.icao24, m);
+      }
+    });
+
+    // remove markers that left bounds or disappeared
+    markers.current.forEach((m, id) => {
+      if (!visible.has(id)) { m.remove(); markers.current.delete(id); }
+    });
+  }, [aircraft, bounds, map]);
+
+  useEffect(() => () => { markers.current.forEach((m) => m.remove()); }, []);
+
+  return null;
+}
+
+// ── fires onBoundsChange whenever the map is moved or zoomed ──────────────────
+function BoundsTracker({ onChange }: { onChange: (b: L.LatLngBounds) => void }) {
+  const map = useMapEvents({
+    moveend: () => onChange(map.getBounds()),
+    zoomend: () => onChange(map.getBounds()),
+  });
+  useEffect(() => { onChange(map.getBounds()); }, [map, onChange]);
+  return null;
+}
+
+// ── top-left status pill ──────────────────────────────────────────────────────
+function StatusPill({ status, count }: { status: string; count: number }) {
+  const cls =
+    status === "connected"   ? "bg-green-950/90 text-green-300 border-green-800" :
+    status === "reconnecting"? "bg-yellow-950/90 text-yellow-300 border-yellow-800" :
+                               "bg-gray-900/90 text-gray-400 border-gray-700";
+  return (
+    <div className={`absolute top-3 left-3 z-[1000] flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium ${cls}`}>
+      <span className={`w-1.5 h-1.5 rounded-full ${status === "connected" ? "bg-green-400 animate-pulse" : status === "reconnecting" ? "bg-yellow-400 animate-pulse" : "bg-gray-500"}`} />
+      {status === "connected" ? `${count} aircraft in view` : status === "reconnecting" ? "Reconnecting…" : "Disconnected"}
+    </div>
+  );
+}
+
+// ── root export ───────────────────────────────────────────────────────────────
+const NYC: L.LatLngTuple = [40.7128, -74.006];
+
+export default function FlightMapInner({ aircraft, status }: { aircraft: Map<string, AircraftData>; status: string }) {
+  const [bounds, setBounds] = useState<L.LatLngBounds | null>(null);
+
+  const visibleCount = bounds
+    ? Array.from(aircraft.values()).filter((ac) => bounds.contains([ac.lat, ac.lon])).length
+    : aircraft.size;
+
+  return (
+    <div className="relative w-full h-full">
+      <StatusPill status={status} count={visibleCount} />
+      <MapContainer center={NYC} zoom={10} className="w-full h-full" zoomControl={false}>
+        <TileLayer
+          url="https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+          attribution='&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com">CARTO</a>'
+          maxZoom={19}
+        />
+        <BoundsTracker onChange={setBounds} />
+        <MarkersLayer aircraft={aircraft} bounds={bounds} />
+      </MapContainer>
+    </div>
+  );
+}

--- a/frontend/app/hooks/useWebSocket.ts
+++ b/frontend/app/hooks/useWebSocket.ts
@@ -21,6 +21,11 @@ interface AircraftUpdateEvent {
   data: AircraftData;
 }
 
+interface AircraftBatchEvent {
+  type: "aircraft_batch";
+  data: AircraftData[];
+}
+
 interface UseWebSocketReturn {
   aircraft: Map<string, AircraftData>;
   status: WsStatus;
@@ -51,11 +56,17 @@ export function useWebSocket(url: string | undefined): UseWebSocketReturn {
 
     ws.onmessage = (event) => {
       try {
-        const msg: AircraftUpdateEvent = JSON.parse(event.data);
+        const msg: AircraftUpdateEvent | AircraftBatchEvent = JSON.parse(event.data);
         if (msg.type === "aircraft_update") {
           setAircraft((prev) => {
             const next = new Map(prev);
             next.set(msg.data.icao24, msg.data);
+            return next;
+          });
+        } else if (msg.type === "aircraft_batch") {
+          setAircraft((prev) => {
+            const next = new Map(prev);
+            for (const ac of msg.data) next.set(ac.icao24, ac);
             return next;
           });
         }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,4 +1,4 @@
-import { FlightBoard } from "@/app/components/FlightBoard/FlightBoard";
+import { FlightMap } from "@/app/components/FlightMap/FlightMap";
 import { ChatPanel } from "@/app/components/Chat/ChatPanel";
 
 export default function Home() {
@@ -16,9 +16,9 @@ export default function Home() {
 
       {/* Main split panel */}
       <main className="flex flex-1 overflow-hidden">
-        {/* Flight Board — left panel */}
+        {/* Flight Map — left panel */}
         <section className="flex-1 border-r border-gray-800 overflow-hidden">
-          <FlightBoard />
+          <FlightMap />
         </section>
 
         {/* Chat — right panel */}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,12 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@types/leaflet": "^1.9.21",
+        "leaflet": "^1.9.4",
         "next": "16.2.4",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "react-leaflet": "^5.0.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1300,6 +1303,17 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1617,6 +1631,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1630,6 +1650,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.39",
@@ -4633,6 +4662,12 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -5557,6 +5592,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,12 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@types/leaflet": "^1.9.21",
+    "leaflet": "^1.9.4",
     "next": "16.2.4",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "react-leaflet": "^5.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/services/broadcaster-lambda/main.py
+++ b/services/broadcaster-lambda/main.py
@@ -9,6 +9,9 @@ from botocore.exceptions import ClientError
 CONNECTIONS_TABLE = os.environ["CONNECTIONS_TABLE"]
 WS_MANAGEMENT_ENDPOINT = os.environ["WS_MANAGEMENT_ENDPOINT"]
 
+# API GW WebSocket max payload is 128 KB; ~160 bytes/aircraft → ~800 per chunk
+CHUNK_SIZE = 700
+
 _ddb = None
 _apigw = None
 
@@ -29,14 +32,16 @@ def get_apigw():
     return _apigw
 
 
-def build_ws_message(ac: dict) -> bytes | None:
+def normalize(ac: dict) -> dict | None:
     hex_id = (ac.get("hex") or "").strip().lower()
     if not hex_id or ac.get("lat") is None or ac.get("lon") is None:
         return None
 
     alt_baro = ac.get("alt_baro")
-    on_ground = alt_baro == "ground"
-    altitude = 0 if on_ground else (int(alt_baro) if isinstance(alt_baro, (int, float)) else 0)
+    on_ground = ac.get("onGround") if "onGround" in ac else (alt_baro == "ground")
+    altitude = ac.get("altitudeFeet") or (
+        0 if on_ground else (int(alt_baro) if isinstance(alt_baro, (int, float)) else 0)
+    )
 
     polled_at = ac.get("polledAt")
     updated_at = (
@@ -45,41 +50,63 @@ def build_ws_message(ac: dict) -> bytes | None:
         else time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     )
 
-    msg = {
-        "type": "aircraft_update",
-        "data": {
-            "icao24": hex_id,
-            "callsign": (ac.get("flight") or "").strip(),
-            "lat": ac.get("lat", 0),
-            "lon": ac.get("lon", 0),
-            "altitude": altitude,
-            "groundSpeed": int(ac.get("gs") or 0),
-            "track": int(ac.get("track") or 0),
-            "onGround": on_ground,
-            "updatedAt": updated_at,
-        },
+    return {
+        "icao24": hex_id,
+        "callsign": (ac.get("flight") or "").strip(),
+        "lat": ac.get("lat", 0),
+        "lon": ac.get("lon", 0),
+        "altitude": altitude,
+        "groundSpeed": int(ac.get("gs") or 0),
+        "track": int(ac.get("track") or 0),
+        "onGround": bool(on_ground),
+        "updatedAt": updated_at,
     }
-    return json.dumps(msg).encode("utf-8")
+
+
+def send_to_connection(conn_id: str, chunks: list[bytes]) -> bool:
+    """Returns True if connection is stale."""
+    apigw = get_apigw()
+    for chunk in chunks:
+        try:
+            apigw.post_to_connection(ConnectionId=conn_id, Data=chunk)
+        except ClientError as e:
+            code = e.response["Error"]["Code"]
+            if code in ("GoneException", "410"):
+                return True
+            print(f"post error {conn_id}: {e}")
+    return False
 
 
 def handler(event, context):
-    # Decode all Kinesis records into aircraft objects
-    aircraft_list: list[dict] = []
+    # Decode Kinesis records, deduplicate by icao24 (last write wins)
+    seen: dict[str, dict] = {}
     for record in event.get("Records", []):
         try:
             raw = base64.b64decode(record["kinesis"]["data"]).decode("utf-8")
             parsed = json.loads(raw)
-            if isinstance(parsed, list):
-                aircraft_list.extend(parsed)
-            elif isinstance(parsed, dict):
-                aircraft_list.append(parsed)
+            items = parsed if isinstance(parsed, list) else [parsed]
+            for ac in items:
+                hex_id = (ac.get("hex") or "").strip().lower()
+                if hex_id:
+                    seen[hex_id] = ac
         except Exception as e:
             print(f"decode error: {e}")
 
-    if not aircraft_list:
+    if not seen:
         return
 
-    # Fetch all active connection IDs
+    # Normalize and build chunked payloads
+    normalized = [n for ac in seen.values() if (n := normalize(ac))]
+    if not normalized:
+        return
+
+    # Split into chunks small enough to fit within API GW's 128 KB message limit
+    chunks: list[bytes] = []
+    for i in range(0, len(normalized), CHUNK_SIZE):
+        batch = normalized[i : i + CHUNK_SIZE]
+        chunks.append(json.dumps({"type": "aircraft_batch", "data": batch}).encode("utf-8"))
+
+    # Fetch active connections
     table = get_ddb().Table(CONNECTIONS_TABLE)
     scan_resp = table.scan(ProjectionExpression="connectionId")
     conn_ids: list[str] = [item["connectionId"] for item in scan_resp.get("Items", [])]
@@ -87,27 +114,11 @@ def handler(event, context):
     if not conn_ids:
         return
 
-    # Build messages and broadcast
-    apigw = get_apigw()
+    # Broadcast — one set of chunk calls per connection
     stale: set[str] = set()
-
-    for ac in aircraft_list:
-        msg = build_ws_message(ac)
-        if not msg:
-            continue
-        for conn_id in conn_ids:
-            if conn_id in stale:
-                continue
-            try:
-                apigw.post_to_connection(ConnectionId=conn_id, Data=msg)
-            except ClientError as e:
-                code = e.response["Error"]["Code"]
-                if code in ("GoneException", "410"):
-                    stale.add(conn_id)
-                else:
-                    print(f"post error {conn_id}: {e}")
-            except Exception as e:
-                print(f"post error {conn_id}: {e}")
+    for conn_id in conn_ids:
+        if send_to_connection(conn_id, chunks):
+            stale.add(conn_id)
 
     # Remove stale connections
     for conn_id in stale:
@@ -116,4 +127,7 @@ def handler(event, context):
         except Exception as e:
             print(f"cleanup error {conn_id}: {e}")
 
-    print(f"broadcast: aircraft={len(aircraft_list)} connections={len(conn_ids)} stale={len(stale)}")
+    print(
+        f"broadcast: aircraft={len(normalized)} chunks={len(chunks)} "
+        f"connections={len(conn_ids)} stale={len(stale)}"
+    )


### PR DESCRIPTION
## Root cause
The broadcaster was calling `post_to_connection` once **per aircraft** — 2,600 sequential HTTP calls × ~20ms each = **52 seconds**, silently hitting the 60s Lambda timeout before most browsers saw data.

## Fix
- Broadcaster deduplicates aircraft by ICAO24 across the Kinesis batch, then groups them into 700-aircraft chunks (~110KB each, under API GW's 128KB limit)
- 2,600 aircraft → **4 API calls** per connection instead of 2,600 — completes in ~80ms
- Fixes field mapping: uses `onGround`/`altitudeFeet` fields now present in Kinesis schema
- Frontend `useWebSocket` handles new `aircraft_batch` event type alongside existing `aircraft_update`

## Also included
- Replace table `FlightBoard` with interactive Leaflet map centered on NYC (zoom 10)
- Plane icons rotated by `track` heading, viewport-filtered, click for popup
- Status pill shows live aircraft count in view

## Test plan
- [ ] Deploy: `cdk deploy api-stack` updates broadcaster Lambda
- [ ] Broadcaster logs show `chunks=4 stale=0` (not timeout)
- [ ] Flight map loads, shows aircraft within a few seconds of page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)