### PR TITLE
fix: remove duplicate CORS headers causing fetch errors

### DIFF
--- a/services/chat-lambda/main.py
+++ b/services/chat-lambda/main.py
@@ -7,18 +7,10 @@ from boto3.dynamodb.conditions import Attr
 from decimal import Decimal
 from fastapi import FastAPI, Query
 from fastapi.responses import StreamingResponse
-from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import AsyncGenerator
 
 app = FastAPI()
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
 
 MODEL_ID = os.environ.get("MODEL_ID", "claude-sonnet-4-20250514")
 MCP_LAMBDA_ARN = os.environ.get("MCP_LAMBDA_ARN", "")


### PR DESCRIPTION
## Summary
- FastAPI's CORSMiddleware was adding `Access-Control-Allow-Origin: *`
- Lambda Function URL CORS config was also adding `Access-Control-Allow-Origin: <origin>`
- Browsers reject responses with duplicate ACAO headers → fetch error on map load
- Fix: remove FastAPI middleware; Lambda Function URL CORS config handles it

🤖 Generated with [Claude Code](https://claude.com/claude-code)