### PR TITLE
fix: replace full-table DynamoDB scan with geohash-2 GSI for viewport queries

### DIFF
--- a/cdk/lib/data-stack.ts
+++ b/cdk/lib/data-stack.ts
@@ -42,6 +42,15 @@ export class DataStack extends cdk.Stack {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
+    // GSI for viewport queries — partition by 2-char geohash cell (~5.6° × 11.25°).
+    // Replaces full-table scans with a handful of targeted parallel queries.
+    this.aircraftTable.addGlobalSecondaryIndex({
+      indexName: 'gh2-index',
+      partitionKey: { name: 'gh2', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.INCLUDE,
+      nonKeyAttributes: ['callsign', 'lat', 'lon', 'altitude', 'groundSpeed', 'track', 'onGround', 'updatedAt', 'ttl'],
+    });
+
     // S3 archive bucket for Firehose
     this.archiveBucket = new s3.Bucket(this, 'PositionsArchive', {
       bucketName: `up-in-the-sky-positions-${this.account}-${this.region}`,

--- a/services/chat-lambda/main.py
+++ b/services/chat-lambda/main.py
@@ -3,7 +3,8 @@ import os
 import time
 import boto3
 import anthropic
-from boto3.dynamodb.conditions import Attr
+from boto3.dynamodb.conditions import Attr, Key
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from decimal import Decimal
 from fastapi import FastAPI, Query
 from fastapi.responses import StreamingResponse
@@ -245,6 +246,63 @@ def decimal_to_float(obj):
     return obj
 
 
+# Precision-2 geohash cell dimensions.
+# 10 bits: 5 lon bits → 360/32 = 11.25° wide, 5 lat bits → 180/32 = 5.625° tall.
+_GH2_CELL_LAT = 180.0 / 32
+_GH2_CELL_LON = 360.0 / 32
+_BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz"
+
+
+def _encode_gh2(lat: float, lon: float) -> str:
+    min_lat, max_lat = -90.0, 90.0
+    min_lon, max_lon = -180.0, 180.0
+    bits = 0
+    hash_val = 0
+    is_lon = True
+    result: list[str] = []
+    while len(result) < 2:
+        if is_lon:
+            mid = (min_lon + max_lon) / 2
+            if lon >= mid:
+                hash_val = (hash_val << 1) | 1
+                min_lon = mid
+            else:
+                hash_val <<= 1
+                max_lon = mid
+        else:
+            mid = (min_lat + max_lat) / 2
+            if lat >= mid:
+                hash_val = (hash_val << 1) | 1
+                min_lat = mid
+            else:
+                hash_val <<= 1
+                max_lat = mid
+        is_lon = not is_lon
+        bits += 1
+        if bits == 5:
+            result.append(_BASE32[hash_val])
+            bits = 0
+            hash_val = 0
+    return "".join(result)
+
+
+def _gh2_cells_in_bbox(
+    min_lat: float, max_lat: float, min_lon: float, max_lon: float
+) -> list[str]:
+    # Snap to the SW corner of the geohash grid cell that contains the SW viewport corner.
+    sw_lat = int((min_lat + 90) / _GH2_CELL_LAT) * _GH2_CELL_LAT - 90
+    sw_lon = int((min_lon + 180) / _GH2_CELL_LON) * _GH2_CELL_LON - 180
+    cells: list[str] = []
+    lat = sw_lat
+    while lat < max_lat:
+        lon = sw_lon
+        while lon < max_lon:
+            cells.append(_encode_gh2(lat + _GH2_CELL_LAT / 2, lon + _GH2_CELL_LON / 2))
+            lon += _GH2_CELL_LON
+        lat += _GH2_CELL_LAT
+    return cells
+
+
 @app.get("/aircraft")
 async def get_aircraft(
     min_lat: float = Query(...),
@@ -254,26 +312,43 @@ async def get_aircraft(
 ):
     table = get_aircraft_table()
     now = int(time.time())
+    cells = _gh2_cells_in_bbox(min_lat, max_lat, min_lon, max_lon)
 
-    items: list[dict] = []
-    kwargs: dict = {
-        "FilterExpression": (
-            Attr("lat").between(Decimal(str(min_lat)), Decimal(str(max_lat)))
-            & Attr("lon").between(Decimal(str(min_lon)), Decimal(str(max_lon)))
-            & Attr("ttl").gt(now)
-        ),
-        "ProjectionExpression": "icao24, callsign, lat, lon, altitude, groundSpeed, track, onGround, updatedAt",
-    }
+    def _query_cell(cell: str) -> list[dict]:
+        items: list[dict] = []
+        kwargs: dict = {
+            "IndexName": "gh2-index",
+            "KeyConditionExpression": Key("gh2").eq(cell),
+            "ProjectionExpression": "icao24, callsign, lat, lon, altitude, groundSpeed, track, onGround, updatedAt, #ttl",
+            "ExpressionAttributeNames": {"#ttl": "ttl"},
+        }
+        while True:
+            resp = table.query(**kwargs)
+            items.extend(resp.get("Items", []))
+            last_key = resp.get("LastEvaluatedKey")
+            if not last_key:
+                break
+            kwargs["ExclusiveStartKey"] = last_key
+        return items
 
-    while True:
-        resp = table.scan(**kwargs)
-        items.extend(resp.get("Items", []))
-        last_key = resp.get("LastEvaluatedKey")
-        if not last_key:
-            break
-        kwargs["ExclusiveStartKey"] = last_key
+    all_items: list[dict] = []
+    max_workers = min(len(cells), 20)
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_query_cell, cell): cell for cell in cells}
+        for future in as_completed(futures):
+            all_items.extend(future.result())
 
-    return {"aircraft": decimal_to_float(items)}
+    # Filter to the exact viewport bounds and exclude TTL-expired items.
+    filtered = [
+        item for item in all_items
+        if (
+            min_lat <= float(item["lat"]) <= max_lat
+            and min_lon <= float(item["lon"]) <= max_lon
+            and int(item.get("ttl", 0)) > now
+        )
+    ]
+
+    return {"aircraft": decimal_to_float(filtered)}
 
 
 @app.get("/health")

--- a/services/normalizer-lambda/src/main/java/com/upinthesky/normalizer/NormalizerHandler.java
+++ b/services/normalizer-lambda/src/main/java/com/upinthesky/normalizer/NormalizerHandler.java
@@ -113,7 +113,36 @@ public class NormalizerHandler implements RequestHandler<KinesisEvent, String> {
         if (a.getGs() != null) item.put("groundSpeed", num(String.valueOf(a.getGs())));
         if (a.getTrack() != null) item.put("track", num(String.valueOf(a.getTrack())));
         item.put("onGround", bool(a.isOnGround()));
+        if (a.getLat() != null && a.getLon() != null) {
+            item.put("gh2", str(geohash(a.getLat(), a.getLon(), 2)));
+        }
         return item;
+    }
+
+    // Encodes (lat, lon) to a Niemeyer base-32 geohash of the given precision.
+    private static final char[] BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz".toCharArray();
+
+    private static String geohash(double lat, double lon, int precision) {
+        double minLat = -90.0, maxLat = 90.0;
+        double minLon = -180.0, maxLon = 180.0;
+        int bits = 0;
+        int hashValue = 0;
+        boolean isLon = true;
+        StringBuilder sb = new StringBuilder(precision);
+        while (sb.length() < precision) {
+            if (isLon) {
+                double mid = (minLon + maxLon) / 2;
+                if (lon >= mid) { hashValue = (hashValue << 1) | 1; minLon = mid; }
+                else             { hashValue <<= 1;                   maxLon = mid; }
+            } else {
+                double mid = (minLat + maxLat) / 2;
+                if (lat >= mid) { hashValue = (hashValue << 1) | 1; minLat = mid; }
+                else             { hashValue <<= 1;                   maxLat = mid; }
+            }
+            isLon = !isLon;
+            if (++bits == 5) { sb.append(BASE32[hashValue]); bits = 0; hashValue = 0; }
+        }
+        return sb.toString();
     }
 
     private int enrichRoutes(List<Map<String, AttributeValue>> items, long now, Context context) {


### PR DESCRIPTION
## Problem

The `/aircraft` endpoint was running a full `table.scan()` on every request, consuming read units for all ~15,000 aircraft before applying the lat/lon `FilterExpression`. With two concurrent users both triggering 8-second polling intervals, this caused two simultaneous full scans — resulting in minute-long hangs.

## Solution

Adds a **precision-2 geohash (gh2) index** to DynamoDB. A geohash-2 cell covers ~5.6° lat × 11.25° lon. A multi-state east-coast viewport intersects ~10 cells; instead of one 15,000-item scan, the API now runs ~10 parallel targeted queries of ~500 items each.

### Changes

- **`services/normalizer-lambda/NormalizerHandler.java`**: Computes `gh2 = geohash(lat, lon, 2)` on every aircraft write (inline implementation, no new dependency).
- **`cdk/lib/data-stack.ts`**: Adds `gh2-index` GSI (INCLUDE projection with the 9 viewport-needed attributes).
- **`services/chat-lambda/main.py`**: Replaces `table.scan()` with `_gh2_cells_in_bbox()` + parallel `ThreadPoolExecutor` queries against `gh2-index`; filters to exact bounds + TTL expiry in Python after merge.

## Performance impact

| Scenario | Before | After |
|---|---|---|
| Multi-state east coast view | 15,000 items scanned | ~10 cells × ~500 items = ~5,000 reads |
| Single-city view | 15,000 items scanned | 1–2 cells × ~500 items = ~500–1,000 reads |
| Concurrent users | Scans multiply | Queries are independent and fast |

## Rollout note

Existing DynamoDB items don't have `gh2` and won't appear in the GSI until the normalizer rewrites them. Since the normalizer's 30-second write cooldown will have expired for all aircraft by the time deployment finishes, all active aircraft will appear in the index within one poller cycle (~2 minutes).

## Test plan
- [ ] Deploy data-stack and verify `gh2-index` GSI is created and backfills within ~2 minutes
- [ ] Verify `/aircraft` returns correct results for a small viewport (e.g., NYC area)
- [ ] Verify `/aircraft` returns correct results for a multi-state east-coast viewport
- [ ] Confirm `/health` still passes
- [ ] Load test with 2+ concurrent users and confirm no hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)